### PR TITLE
Change ISR vector name based on board preprocessor flag

### DIFF
--- a/src/Camino.cpp
+++ b/src/Camino.cpp
@@ -26,8 +26,13 @@
   #define RXENN             RXEN0
   #define TXENN             TXEN0
   #define RXCIEN            RXCIE0
-  #define USARTN_RX_vect    USART_RX_vect    // no number for some reason
-  #define USARTN_UDRE_vect  USART_UDRE_vect  // no number for some reason
+  #ifdef ARDUINO_AVR_UNO
+    #define USARTN_RX_vect    USART_RX_vect
+    #define USARTN_UDRE_vect  USART_UDRE_vect
+  #else
+    #define USARTN_RX_vect    USART0_RX_vect
+    #define USARTN_UDRE_vect  USART0_UDRE_vect
+  #endif
   #define UDRN              UDR0
   #define UDRIEN            UDRIE0
 #elif PORT == 1


### PR DESCRIPTION
This should fix `PORT=0` not working on ATmega2560 as mentioned in issue #1 .

@jorianxk I don't have any Arduinos (Uno or Mega) on hand... Any chance you could test these boards before I merge and release?


Closes: #1 