### PR TITLE
Remove Serial.set_input_flow_control call

### DIFF
--- a/camino/__init__.py
+++ b/camino/__init__.py
@@ -24,7 +24,6 @@ class CaminoResendException(CaminoException):
 class SerialConnection:
     def __init__(self, port="/dev/ttyS0", baud=115200):
         self.port = Serial(port=port, baudrate=baud, timeout=COMMAND_TIMEOUT_PERIOD_S)
-        self.port.set_input_flow_control(True)
 
     def read_byte(self):
         b = self.port.read(1)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Camino
-version=1.1.0
+version=1.2.0
 author=Nathan Wachholz <camino@nathanwachholz.com>
 maintainer=Nathan Wachholz <camino@nathanwachholz.com>
 sentence=A library for controlling an Arduino from Python over Serial.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="camino",
-    version="1.1.0",
+    version="1.2.0",
     author="Nathan Wachholz",
     author_email="camino@nathanwachholz.com",
     description="A library for controlling an Arduino from Python over Serial",


### PR DESCRIPTION
Closes: #4 

`Serial.set_input_flow_control` is not supported on Windows, causing `camino` to break.

The library appears to work fine without the call over a plain USB connection. Perhaps it is important in some hardware setups, but for now I'm just removing it.
