### PR TITLE
Add returns for scalar types (byte, short, int, long)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ To allow all callables to have the same type, data is returned using a number
 of helper functions, rather than `return` statements.
 
 To return data to Python, use one of the available `returns(...)` methods. 
-At the moment, there are 3 possible arguments for `returns(...)`:
+At the moment, there are a few possible arguments for `returns(...)`:
 
 ```C
 void returns(const char* string); // returns("hello");
-void returns(byte v); // returns(1);
+void returns(byte|short|int|long v); // returns(1);
 void returns(byte dataLength, data *dataArray); // returns(dataLength, data); as in echo
 ```
 

--- a/src/Camino.cpp
+++ b/src/Camino.cpp
@@ -361,7 +361,7 @@ ISR(USARTN_UDRE_vect) {
 }
 
 void numberOfCallables(byte dataLength, byte *dataArray) {
-  returns(NUM_INTERNAL_CALLABLES + numberOfExternalCallables);
+  returns((byte) (NUM_INTERNAL_CALLABLES + numberOfExternalCallables));
 }
 
 void getNthCallable(byte dataLength, byte *dataArray) {
@@ -395,8 +395,7 @@ void _analogWrite(byte dataLength, byte *dataArray) {
 
 void _analogRead(byte dataLength, byte *dataArray) {
   int value = analogRead(dataArray[0]);
-  byte arr[2] = {(byte) (value % 256), (byte) value};
-  returns(2, arr);
+  returns((short) value);
 }
 
 void returns(const char* string) {
@@ -415,8 +414,16 @@ void returns(byte dataLength, byte *dataArray) {
   responseHasData = 1;
 }
 
-void returns(byte v) {
-  packetDataLength = 1;
-  responseDataArray[0] = v;
-  responseHasData = 1;
+#define returnsType(type) void returns(type v) {\
+  packetDataLength = sizeof(type);\
+  for(byte i = 0; i < packetDataLength; i++) {\
+    responseDataArray[i] = (byte) (v % 256);\
+    v = v / 256;\
+  }\
+  responseHasData = 1;\
 }
+
+returnsType(byte);
+returnsType(short);
+returnsType(int);
+returnsType(long);

--- a/src/Camino.h
+++ b/src/Camino.h
@@ -64,5 +64,8 @@ byte numberOfExternalCallables = sizeof(callables) / sizeof(Callable);
 void returns(const char* string);
 void returns(byte dataLength, byte dataArray[]);
 void returns(byte v);
+void returns(short v);
+void returns(int v);
+void returns(long v);
 
 #endif


### PR DESCRIPTION
Closes #10 

This also fixes the internal `_analogRead` callable.
