### PR TITLE
Refactor to use `logging` package rather than print(x).

### DIFF
--- a/camino/__init__.py
+++ b/camino/__init__.py
@@ -95,11 +95,11 @@ class SerialConnection:
                 return response
             except CaminoException as e:
                 last_exception = e
-                print(f"Got error on attempt {attempt_number + 1}/{SEND_ATTEMPTS}: {e}")
+                print(f"[camino] Got error on communication attempt {attempt_number + 1}/{SEND_ATTEMPTS}: {e}")
                 # flushing
                 self.port.flush()
         raise CaminoException(
-            f"All {SEND_ATTEMPTS} attempts to communicate with device failed."
+            f"All {SEND_ATTEMPTS} consecutive attempts to communicate with device failed."
         ) from last_exception
 
 
@@ -149,9 +149,10 @@ class Callable:
 
 
 class Arduino:
-    def __init__(self, serial, address=0):
+    def __init__(self, serial, address=0, silent=False):
         self.serial = serial
         self.address = address
+        self.silent = silent
         self.callables = {}
         self._add_callable(Callable(self, 0, "num_calls"))
         self._add_callable(Callable(self, 1, "get_nth_call"))
@@ -160,10 +161,10 @@ class Arduino:
     def _add_callable(self, _callable):
         self.callables[_callable.name] = _callable
         setattr(self, _callable.name, _callable.call)
-        print("Callable added: {}".format(_callable.name))
+        if not self.silent: print("[camino] Callable added: {}".format(_callable.name))
 
     def _fetch_callables(self):
         callable_count = self.num_calls(out=int)
-        print("There are", callable_count, "callables")
+        if not self.silent: print(f"[camino] There are", callable_count, "callables")
         for i in range(len(self.callables), callable_count):
             self._add_callable(Callable(self, i))


### PR DESCRIPTION
I am making a cli program with camino, and these are some things that I added to make the cli experience better:
 - ~~`print(x)` statements from camino now start with `"[camino] "`~~
 - ~~`Arduino` constructor now takes optional `silent=False` argument~~
 - `print(x)` statements now use `logging.info/debug/warning/etc`
 
These might be personal preference, but I think they are good additions.
