### PR TITLE
Update Camino.cpp

### DIFF
--- a/src/Camino.cpp
+++ b/src/Camino.cpp
@@ -390,7 +390,7 @@ void _digitalRead(byte dataLength, byte *dataArray) {
 }
 
 void _analogWrite(byte dataLength, byte *dataArray) {
-  analogWrite(dataArray[0], dataArray[1]*256 + dataArray[2]);
+  analogWrite(dataArray[0], dataArray[1]);
 }
 
 void _analogRead(byte dataLength, byte *dataArray) {


### PR DESCRIPTION
Line line 393 in Camino.cpp, analog write only accepts a value between 0-254 Analog read is 10 bit, 0-1023
Analog write is 0-255